### PR TITLE
DSPDC-320 Use TLS connections between Kafka and the Transporter manager

### DIFF
--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -2,13 +2,18 @@
 org.broadinstitute.transporter {
 
     kafka {
-        bootstrap-servers = ["{{env "BOOTSTRAP_SERVICE"}}.{{env "NAMESPACE"}}:9092"]
-        application-id = "{{env "NAMESPACE"}}-transporter-agent"
+        bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]
+        application-id = "{{env "KAFKA_APPLICATION_ID"}}"
 
         topics {
             request-topic = "{{env "REQUEST_TOPIC"}}"
             progress-topic = "{{env "PROGRESS_TOPIC"}}"
             result-topic = "{{env "RESULT_TOPIC"}}"
+        }
+
+        tls {
+            truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
+            truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
         }
     }
 

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/entrypoint.sh.ctmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 declare -r HEAP_MEM=${AGENT_HEAP_SIZE:-512m}
 
@@ -15,6 +16,15 @@ declare -ra JAVA_OPTS_ARRAY=(
    -XX:+PrintGCDateStamps
    -XX:+PrintGCDetails
 )
+
+# Configure the JVM to trust broker TLS certificates.
+keytool \
+   -keystore '{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}' \
+   -storepass '{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}' \
+   -storetype JKS \
+   -noprompt \
+   -alias CARoot \
+   -import -file /etc/tls/ca.crt
 
 # Inject options into normal entrypoint.
 JAVA_OPTS="${JAVA_OPTS_ARRAY[*]}" exec /app/bin/transporter-aws-to-gcp-agent

--- a/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-{{with $path := env "SQL_LOGIN_PATH"}}{{with $secret := vault $path}}{{with $ns := env "NAMESPACE"}}
-
-declare -r LIQUIBASE_HOST=cloudsql-proxy.{{$ns}}
-declare -r LIQUIBASE_DATABASE={{$secret.Data.db_name}}
-declare -r LIQUIBASE_USERNAME={{$secret.Data.username}}
-declare -r LIQUIBASE_PASSWORD={{$secret.Data.password}}
+declare -r LIQUIBASE_HOST='{{env "DB_URL"}}'
+declare -r LIQUIBASE_DATABASE='{{env "DB_NAME"}}'
+declare -r LIQUIBASE_USERNAME='{{env "DB_USERNAME"}}'
+declare -r LIQUIBASE_PASSWORD='{{env "DB_PASSWORD"}}'
 
 exec /usr/local/bin/entrypoint.sh ${@}
-
-{{end}}{{end}}{{end}}

--- a/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
@@ -1,8 +1,9 @@
 #!/bin/bash
-
+{{with $secret := vault (env "DB_LOGIN_SECRETS_PATH")}}
 declare -r LIQUIBASE_HOST='{{env "DB_URL"}}'
-declare -r LIQUIBASE_DATABASE='{{env "DB_NAME"}}'
-declare -r LIQUIBASE_USERNAME='{{env "DB_USERNAME"}}'
-declare -r LIQUIBASE_PASSWORD='{{env "DB_PASSWORD"}}'
+declare -r LIQUIBASE_DATABASE='{{$secret.Data.db_name}}'
+declare -r LIQUIBASE_USERNAME='{{$secret.Data.username}}'
+declare -r LIQUIBASE_PASSWORD='{{$secret.Data.password}}'
 
 exec /usr/local/bin/entrypoint.sh ${@}
+{{end}}

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -9,7 +9,10 @@ org.broadinstitute.transporter {
     kafka {
         connection {
             bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]
-            //ssl-trustore = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
+            //tls {
+                //truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
+                //truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
+            //}
         }
 
         topics {

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -1,11 +1,11 @@
 org.broadinstitute.transporter {
-
+    {{with $secret := vault (env "DB_LOGIN_SECRETS_PATH")}}
     db {
-        connect-url = "jdbc:postgresql://{{env "DB_URL"}}/{{env "DB_NAME"}}"
-        username = "{{env "DB_USERNAME"}}"
-        password = "{{env "DB_PASSWORD"}}"
+        connect-url = "jdbc:postgresql://{{env "DB_URL"}}/{{$secret.Data.db_name}}"
+        username = "{{$secret.Data.username}}"
+        password = "{{$secret.Data.password}}"
     }
-
+    {{end}}
     kafka {
         connection {
             bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -1,17 +1,15 @@
-{{with $path := env "SQL_LOGIN_PATH"}}{{with $secret := vault $path}}{{with $ns := env "NAMESPACE"}}
 org.broadinstitute.transporter {
 
-    submission-interval: 10s
-
     db {
-        username = {{$secret.Data.username}}
-        password = {{$secret.Data.password}}
-        connect-url = "jdbc:postgresql://cloudsql-proxy.{{$ns}}/{{$secret.Data.db_name}}"
+        connect-url = "jdbc:postgresql://{{env "DB_URL"}}/{{env "DB_NAME"}}"
+        username = "{{env "DB_USERNAME"}}"
+        password = "{{env "DB_PASSWORD"}}"
     }
 
     kafka {
         connection {
-            bootstrap-servers = ["{{env "BOOTSTRAP_SERVICE"}}.{{$ns}}:9092"]
+            bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]
+            //ssl-trustore = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
         }
 
         topics {
@@ -26,4 +24,3 @@ org.broadinstitute.transporter {
         max-in-flight = {{env "MAX_CONCURRENT_TRANSFERS"}}
     }
 }
-{{end}}{{end}}{{end}}

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -9,10 +9,10 @@ org.broadinstitute.transporter {
     kafka {
         connection {
             bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]
-            //tls {
-                //truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
-                //truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
-            //}
+            tls {
+                truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
+                truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
+            }
         }
 
         topics {

--- a/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 declare -r HEAP_MEM=${TRANSPORTER_HEAP_SIZE:-1g}
 
@@ -15,6 +16,12 @@ declare -ra JAVA_OPTS_ARRAY=(
    -XX:+PrintGCDateStamps
    -XX:+PrintGCDetails
 )
+
+# Configure the JVM to trust broker TLS certificates.
+keytool -import \
+   -keystore '{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}' \
+   -alias CARoot \
+   -file /etc/tls/ca.cert
 
 # Inject options into normal entrypoint.
 JAVA_OPTS="${JAVA_OPTS_ARRAY[*]}" exec /app/bin/transporter-manager

--- a/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
@@ -18,11 +18,13 @@ declare -ra JAVA_OPTS_ARRAY=(
 )
 
 # Configure the JVM to trust broker TLS certificates.
-keytool -import \
+keytool \
    -keystore '{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}' \
+   -storepass '{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}' \
+   -storetype JKS \
+   -noprompt \
    -alias CARoot \
-   -file /etc/tls/ca.crt \
-   -keypass '{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}'
+   -import -file /etc/tls/ca.crt
 
 # Inject options into normal entrypoint.
 JAVA_OPTS="${JAVA_OPTS_ARRAY[*]}" exec /app/bin/transporter-manager

--- a/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/entrypoint.sh.ctmpl
@@ -21,7 +21,8 @@ declare -ra JAVA_OPTS_ARRAY=(
 keytool -import \
    -keystore '{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}' \
    -alias CARoot \
-   -file /etc/tls/ca.cert
+   -file /etc/tls/ca.crt \
+   -keypass '{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}'
 
 # Inject options into normal entrypoint.
 JAVA_OPTS="${JAVA_OPTS_ARRAY[*]}" exec /app/bin/transporter-manager

--- a/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
+++ b/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
@@ -7,7 +7,6 @@ spec:
     version: 2.2.1
     replicas: 3
     listeners:
-      plain: {}
       tls: {}
     config:
       offsets.topic.replication.factor: 3
@@ -35,4 +34,3 @@ spec:
       deleteClaim: false
   entityOperator:
     topicOperator: {}
-    userOperator: {}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -1,6 +1,7 @@
 {{with $env := env "ENVIRONMENT"}}
 {{with $app := env "APPLICATION_NAME"}}
 {{with $project := env "INGEST_PROJECT"}}
+{{with $owner := env "OWNER"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -44,7 +45,9 @@ spec:
               value: /etc/vault/token
 
             - name: KAFKA_BOOTSTRAP_URL
-              value: {{$app}}-cluster-kafka-bootstrap
+              value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
+            - name: KAFKA_APPLICATION_ID
+              value: {{$owner}}-transporter-agent
             - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
               value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
@@ -93,4 +96,4 @@ spec:
               subPath: transporter-aws-to-gcp-agent/gcs-writer-sa.json
             - name: ca-cert
               mountPath: /etc/tls
-{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -1,42 +1,66 @@
-{{with $env := env "ENVIRONMENT"}}{{with $app := env "APPLICATION_NAME"}}{{with $project := env "INGEST_PROJECT"}}
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $project := env "INGEST_PROJECT"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: transporter-agent
 spec:
-  replicas: 16
+  replicas: {{if (eq $env "prod")}}16{{else}}2{{end}}
   template:
     metadata:
       labels:
         app: transporter-agent
     spec:
       serviceAccountName: transporter-agent-sa
+      volumes:
+        - name: token
+          secret:
+            secretName: vault-token
+            items:
+              - key: token
+                path: token
+                mode: 0444
+        - name: ca-cert
+          secret:
+            secretName: {{$app}}-cluster-cluster-ca-cert
+            items:
+              - key: ca.crt
+                path: ca.crt
+                mode: 0444
+        - name: appdir
+          emptyDir: {}
       initContainers:
         - name: transporter-aws-to-gcp-agent-config
           image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:4a4a2c5
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: token
+              mountPath: /etc/vault
+            - name: appdir
+              mountPath: /working
           env:
             - name: VAULT_TOKEN_FILE
               value: /etc/vault/token
-            - name: AWS_SECRETS_PATH
-              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/aws
-            - name: GCS_WRITER_SA_PATH
-              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
-            - name: BOOTSTRAP_SERVICE
+
+            - name: KAFKA_BOOTSTRAP_URL
               value: {{$app}}-cluster-kafka-bootstrap
-            - name: NAMESPACE
-              value: {{env "OWNER"}}
+            - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
+              value: /tmp/client.truststore.jks
+            - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
+              value: required-by-keytool-but-not-meaningful-outside-of-pod
+
             - name: REQUEST_TOPIC
               value: transporter.requests
             - name: PROGRESS_TOPIC
               value: transporter.progress
             - name: RESULT_TOPIC
               value: transporter.results
-          volumeMounts:
-            - name: token
-              mountPath: /etc/vault
-            - name: appdir
-              mountPath: /working
+
+            - name: AWS_SECRETS_PATH
+              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/aws
+            - name: GCS_WRITER_SA_PATH
+              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
           image: broadinstitute/transporter-aws-to-gcp-agent:37ee941b10e4cb6ace5a91054482e66e1bd875ee
@@ -67,14 +91,6 @@ spec:
             - name: appdir
               mountPath: /secrets/gcs/credentials.json
               subPath: transporter-aws-to-gcp-agent/gcs-writer-sa.json
-      volumes:
-        - name: token
-          secret:
-            secretName: vault-token
-            items:
-              - key: token
-                path: token
-                mode: 0444
-        - name: appdir
-          emptyDir: {}
+            - name: ca-cert
+              mountPath: /etc/tls
 {{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -32,7 +32,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-aws-to-gcp-agent-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:4a4a2c5
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:8d36b99
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -63,7 +63,7 @@ spec:
               value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
-          image: broadinstitute/transporter-aws-to-gcp-agent:37ee941b10e4cb6ace5a91054482e66e1bd875ee
+          image: broadinstitute/transporter-aws-to-gcp-agent:fe99900b8a04653d4ff362e109b5d743c56d9900
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -32,7 +32,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:35ce9be
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:8d36b99
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -67,7 +67,7 @@ spec:
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
         - name: transporter-manager-migrations
-          image: broadinstitute/transporter-manager-migrations:116e9717846a97b2512d3c2880a8a243a904c17b
+          image: broadinstitute/transporter-manager-migrations:fe99900b8a04653d4ff362e109b5d743c56d9900
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh", "liquibase", "update" ]
           volumeMounts:
@@ -76,7 +76,7 @@ spec:
               subPath: transporter-manager-migrations/entrypoint.sh
       containers:
         - name: transporter-manager
-          image: broadinstitute/transporter-manager:116e9717846a97b2512d3c2880a8a243a904c17b
+          image: broadinstitute/transporter-manager:fe99900b8a04653d4ff362e109b5d743c56d9900
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -25,23 +25,23 @@ spec:
                 mode: 0444
         - name: ca-cert
           secret:
-            secretName: {{$app}}-cluster-ca-cert
+            secretName: {{$app}}-cluster-cluster-ca-cert
             items:
-              - key: ca.cert
-                path: ca.cert
+              - key: ca.crt
+                path: ca.crt
                 mode: 0444
         - name: appdir
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:864996f
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:648c0a5
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
               mountPath: /etc/vault
             - name: appdir
               mountPath: /working
-            - name: ca.cert
+            - name: ca-cert
               mountPath: /etc/tls
           env:
             - name: ENVIRONMENT
@@ -60,8 +60,10 @@ spec:
 
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
-            - name: KAFKA_TLS_TRUSTSTORE_PATH
+            - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
               value: /etc/tls/client.truststore.jks
+            - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
+              value: qwertyuiop1234567890 # FIXME
 
             - name: REQUEST_TOPIC
               value: transporter.requests
@@ -95,10 +97,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 1000m
-              memory: 1152Mi
+              cpu: 500m
+              memory: 1728Mi
             limits:
-              memory: 1280Mi
+              memory: 1920Mi
           volumeMounts:
             - name: appdir
               mountPath: /etc/application.conf

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -34,15 +34,13 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:8d8a484
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:f6fd48f
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
               mountPath: /etc/vault
             - name: appdir
               mountPath: /working
-            - name: ca-cert
-              mountPath: /etc/tls
           env:
             - name: ENVIRONMENT
               value: {{$env}}
@@ -61,7 +59,7 @@ spec:
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
             - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
-              value: /etc/tls/client.truststore.jks
+              value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
               value: qwertyuiop1234567890 # FIXME
 
@@ -109,6 +107,8 @@ spec:
             - name: appdir
               mountPath: /etc/entrypoint.sh
               subPath: transporter-manager/entrypoint.sh
+            - name: ca-cert
+              mountPath: /etc/tls
           readinessProbe:
             httpGet:
               path: /status

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -34,7 +34,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:648c0a5
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:8d8a484
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -34,7 +34,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:f6fd48f
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:35ce9be
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -75,7 +75,7 @@ spec:
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
         - name: transporter-manager-migrations
-          image: broadinstitute/transporter-manager-migrations:37ee941b10e4cb6ace5a91054482e66e1bd875ee
+          image: broadinstitute/transporter-manager-migrations:116e9717846a97b2512d3c2880a8a243a904c17b
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh", "liquibase", "update" ]
           volumeMounts:
@@ -84,7 +84,7 @@ spec:
               subPath: transporter-manager-migrations/entrypoint.sh
       containers:
         - name: transporter-manager
-          image: broadinstitute/transporter-manager:37ee941b10e4cb6ace5a91054482e66e1bd875ee
+          image: broadinstitute/transporter-manager:116e9717846a97b2512d3c2880a8a243a904c17b
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -1,8 +1,6 @@
 {{with $env := env "ENVIRONMENT"}}
 {{with $app := env "APPLICATION_NAME"}}
 {{with $owner := env "OWNER"}}
-{{with $sql_login_path := printf "secret/dsde/monster/%s/%s/%s/cloudsql/logins/%s" $env $app (env "INGEST_PROJECT") $owner}}
-{{with $sql_login := secret $sql_login_path}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -42,26 +40,20 @@ spec:
             - name: appdir
               mountPath: /working
           env:
-            - name: ENVIRONMENT
-              value: {{$env}}
             - name: VAULT_TOKEN_FILE
               value: /etc/vault/token
 
             - name: DB_URL
               value: "cloudsql-proxy.{{$owner}}"
-            - name: DB_NAME
-              value: {{$sql_login.Data.db_name}}
-            - name: DB_USERNAME
-              value: {{$sql_login.Data.username}}
-            - name: DB_PASSWORD
-              value: {{$sql_login.Data.password}}
+            - name: DB_LOGIN_SECRETS_PATH
+              value: {{printf "secret/dsde/monster/%s/%s/%s/cloudsql/logins/%s" $env $app (env "INGEST_PROJECT") $owner}}
 
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
             - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
               value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
-              value: qwertyuiop1234567890 # FIXME
+              value: required-by-keytool-but-not-meaningful-outside-of-pod
 
             - name: REQUEST_TOPIC
               value: transporter.requests
@@ -125,4 +117,4 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 10
             failureThreshold: 3
-{{end}}{{end}}{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -1,4 +1,8 @@
-{{with $env := env "ENVIRONMENT"}}{{with $app := env "APPLICATION_NAME"}}{{with $owner := env "OWNER"}}
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $owner := env "OWNER"}}
+{{with $sql_login_path := printf "secret/dsde/monster/%s/%s/%s/cloudsql/logins/%s" $env $app (env "INGEST_PROJECT") $owner}}
+{{with $sql_login := secret $sql_login_path}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -11,36 +15,65 @@ spec:
         app: transporter-manager
     spec:
       serviceAccountName: transporter-manager-sa
+      volumes:
+        - name: token
+          secret:
+            secretName: vault-token
+            items:
+              - key: token
+                path: token
+                mode: 0444
+        - name: ca-cert
+          secret:
+            secretName: {{$app}}-cluster-ca-cert
+            items:
+              - key: ca.cert
+                path: ca.cert
+                mode: 0444
+        - name: appdir
+          emptyDir: {}
       initContainers:
         - name: transporter-manager-config
           image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:864996f
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: token
+              mountPath: /etc/vault
+            - name: appdir
+              mountPath: /working
+            - name: ca.cert
+              mountPath: /etc/tls
           env:
             - name: ENVIRONMENT
               value: {{$env}}
             - name: VAULT_TOKEN_FILE
               value: /etc/vault/token
-            - name: SQL_LOGIN_PATH
-              value: secret/dsde/monster/{{$env}}/{{$app}}/{{env "INGEST_PROJECT"}}/cloudsql/logins/{{$owner}}
-            - name: NAMESPACE
-              value: {{$owner}}
-            - name: BOOTSTRAP_SERVICE
-              value: {{$app}}-cluster-kafka-bootstrap
+
+            - name: DB_URL
+              value: "cloudsql-proxy.{{$owner}}"
+            - name: DB_NAME
+              value: {{$sql_login.Data.db_name}}
+            - name: DB_USERNAME
+              value: {{$sql_login.Data.username}}
+            - name: DB_PASSWORD
+              value: {{$sql_login.Data.password}}
+
+            - name: KAFKA_BOOTSTRAP_URL
+              value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
+            - name: KAFKA_TLS_TRUSTSTORE_PATH
+              value: /etc/tls/client.truststore.jks
+
             - name: REQUEST_TOPIC
               value: transporter.requests
             - name: PROGRESS_TOPIC
               value: transporter.progress
             - name: RESULT_TOPIC
               value: transporter.results
+
             - name: SUBMISSION_INTERVAL
               value: 5s
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
-          volumeMounts:
-            - name: token
-              mountPath: /etc/vault
-            - name: appdir
-              mountPath: /working
         - name: transporter-manager-migrations
           image: broadinstitute/transporter-manager-migrations:37ee941b10e4cb6ace5a91054482e66e1bd875ee
           imagePullPolicy: IfNotPresent
@@ -90,14 +123,4 @@ spec:
             periodSeconds: 20
             timeoutSeconds: 10
             failureThreshold: 3
-      volumes:
-        - name: token
-          secret:
-            secretName: vault-token
-            items:
-              - key: token
-                path: token
-                mode: 0444
-        - name: appdir
-          emptyDir: {}
-{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{end}}


### PR DESCRIPTION
Also, rip all vault paths out of the manager's init containers to make changing things around simpler in the future.