### PR TITLE
DSPDC-324 DSPDC-325 Pass SCRAM info through to Transporter deployments

### DIFF
--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -15,9 +15,10 @@ org.broadinstitute.transporter {
             truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
             truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
         }
-        scram-sha {
-            username = "{{env "KAFKA_SCRAM_SHA_USERNAME"}}"
-            password = "{{env "KAFKA_SCRAM_SHA_PASSWORD"}}"
+        scram {
+            username = "{{env "KAFKA_SCRAM_USERNAME"}}"
+            password = "{{env "KAFKA_SCRAM_PASSWORD"}}"
+            hash-algorithm = "{{env "KAFKA_SCRAM_ALGORITHM"}}"
         }
     }
 

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -15,6 +15,10 @@ org.broadinstitute.transporter {
             truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
             truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
         }
+        scram-sha {
+            username = "{{env "KAFKA_SCRAM_SHA_USERNAME"}}"
+            password = "{{env "KAFKA_SCRAM_SHA_PASSWORD"}}"
+        }
     }
 
     runner-config {

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -13,6 +13,10 @@ org.broadinstitute.transporter {
                 truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
                 truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
             }
+            scram-sha {
+                username = "{{env "KAFKA_SCRAM_SHA_USERNAME"}}"
+                password = "{{env "KAFKA_SCRAM_SHA_PASSWORD"}}"
+            }
         }
 
         topics {

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -13,9 +13,10 @@ org.broadinstitute.transporter {
                 truststore-path = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PATH"}}"
                 truststore-password = "{{env "KAFKA_CLUSTER_TRUSTSTORE_PASSWORD"}}"
             }
-            scram-sha {
-                username = "{{env "KAFKA_SCRAM_SHA_USERNAME"}}"
-                password = "{{env "KAFKA_SCRAM_SHA_PASSWORD"}}"
+            scram {
+                username = "{{env "KAFKA_SCRAM_USERNAME"}}"
+                password = "{{env "KAFKA_SCRAM_PASSWORD"}}"
+                hash-algorithm = "{{env "KAFKA_SCRAM_ALGORITHM"}}"
             }
         }
 

--- a/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
+++ b/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
@@ -7,7 +7,9 @@ spec:
     version: 2.2.1
     replicas: 3
     listeners:
-      tls: {}
+      tls:
+        authentication:
+          type: scram-sha-512
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -33,7 +33,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-aws-to-gcp-agent-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:8d36b99
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:d3c5581
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -52,6 +52,15 @@ spec:
               value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
               value: required-by-keytool-but-not-meaningful-outside-of-pod
+            - name: KAFKA_SCRAM_USERNAME
+              value: transporter-agent-user
+            - name: KAFKA_SCRAM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: transporter-agent-user
+                  key: password
+            - name: KAFKA_SCRAM_ALGORITHM
+              value: sha-512
 
             - name: REQUEST_TOPIC
               value: transporter.requests
@@ -66,7 +75,7 @@ spec:
               value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
-          image: broadinstitute/transporter-aws-to-gcp-agent:fe99900b8a04653d4ff362e109b5d743c56d9900
+          image: broadinstitute/transporter-aws-to-gcp-agent:59ff5327a291ccbb98a8407d2a65d8abeaef2814
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -33,7 +33,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-aws-to-gcp-agent-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:d3c5581
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:d688a33
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -75,7 +75,7 @@ spec:
               value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
-          image: broadinstitute/transporter-aws-to-gcp-agent:59ff5327a291ccbb98a8407d2a65d8abeaef2814
+          image: broadinstitute/transporter-aws-to-gcp-agent:619d22abea932c615d081d4f8a61249e2cb49508
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -75,7 +75,7 @@ spec:
               value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
-          image: broadinstitute/transporter-aws-to-gcp-agent:619d22abea932c615d081d4f8a61249e2cb49508
+          image: broadinstitute/transporter-aws-to-gcp-agent:fb7b732b3831a713b1a96b156328d220438f96fd
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -32,7 +32,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:8d36b99
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:d3c5581
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -54,6 +54,15 @@ spec:
               value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD
               value: required-by-keytool-but-not-meaningful-outside-of-pod
+            - name: KAFKA_SCRAM_USERNAME
+              value: transporter-manager-user
+            - name: KAFKA_SCRAM_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: transporter-manager-user
+                  key: password
+            - name: KAFKA_SCRAM_ALGORITHM
+              value: sha-512
 
             - name: REQUEST_TOPIC
               value: transporter.requests
@@ -67,7 +76,7 @@ spec:
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
         - name: transporter-manager-migrations
-          image: broadinstitute/transporter-manager-migrations:fe99900b8a04653d4ff362e109b5d743c56d9900
+          image: broadinstitute/transporter-manager-migrations:59ff5327a291ccbb98a8407d2a65d8abeaef2814
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh", "liquibase", "update" ]
           volumeMounts:
@@ -76,7 +85,7 @@ spec:
               subPath: transporter-manager-migrations/entrypoint.sh
       containers:
         - name: transporter-manager
-          image: broadinstitute/transporter-manager:fe99900b8a04653d4ff362e109b5d743c56d9900
+          image: broadinstitute/transporter-manager:59ff5327a291ccbb98a8407d2a65d8abeaef2814
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -32,7 +32,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:d3c5581
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:d688a33
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: token
@@ -76,7 +76,7 @@ spec:
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
         - name: transporter-manager-migrations
-          image: broadinstitute/transporter-manager-migrations:59ff5327a291ccbb98a8407d2a65d8abeaef2814
+          image: broadinstitute/transporter-manager-migrations:619d22abea932c615d081d4f8a61249e2cb49508
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh", "liquibase", "update" ]
           volumeMounts:
@@ -85,7 +85,7 @@ spec:
               subPath: transporter-manager-migrations/entrypoint.sh
       containers:
         - name: transporter-manager
-          image: broadinstitute/transporter-manager:59ff5327a291ccbb98a8407d2a65d8abeaef2814
+          image: broadinstitute/transporter-manager:619d22abea932c615d081d4f8a61249e2cb49508
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -76,7 +76,7 @@ spec:
             - name: MAX_CONCURRENT_TRANSFERS
               value: "1000"
         - name: transporter-manager-migrations
-          image: broadinstitute/transporter-manager-migrations:619d22abea932c615d081d4f8a61249e2cb49508
+          image: broadinstitute/transporter-manager-migrations:fb7b732b3831a713b1a96b156328d220438f96fd
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh", "liquibase", "update" ]
           volumeMounts:
@@ -85,7 +85,7 @@ spec:
               subPath: transporter-manager-migrations/entrypoint.sh
       containers:
         - name: transporter-manager
-          image: broadinstitute/transporter-manager:619d22abea932c615d081d4f8a61249e2cb49508
+          image: broadinstitute/transporter-manager:fb7b732b3831a713b1a96b156328d220438f96fd
           imagePullPolicy: IfNotPresent
           command: [ "/bin/bash", "/etc/entrypoint.sh" ]
           env:


### PR DESCRIPTION
Manually confirmed that these settings work, and that Kafka rejects connections with bad auth info.