### PR TITLE
Ra dspdc 266

### DIFF
--- a/init-containers/cloudsql-proxy/Dockerfile
+++ b/init-containers/cloudsql-proxy/Dockerfile
@@ -1,5 +1,0 @@
-FROM broadinstitute/configurator-base:1.0.2
-
-COPY cloudsql-proxy /configs/cloudsql-proxy/
-
-CMD /usr/local/bin/cp-config.sh

--- a/init-containers/cloudsql-proxy/cloudsql-proxy/cloudsql-proxy-sa.json.ctmpl
+++ b/init-containers/cloudsql-proxy/cloudsql-proxy/cloudsql-proxy-sa.json.ctmpl
@@ -1,1 +1,0 @@
-{{with $path := env "SA_VAULT_PATH"}}{{with $secret := vault $path}}{{$secret.Data | toJSON}}{{end}}{{end}}

--- a/init-containers/cloudsql-proxy/cloudsql-proxy/entrypoint.sh.ctmpl
+++ b/init-containers/cloudsql-proxy/cloudsql-proxy/entrypoint.sh.ctmpl
@@ -1,5 +1,0 @@
-{{with $path := env "INSTANCE_VAULT_PATH"}}{{with $secret := vault $path}}
-exec /cloud_sql_proxy \
-    -instances={{$secret.Data.connection_name}}=tcp:0.0.0.0:5432 \
-    -credential_file=/secrets/cloudsql/credentials.json
-{{end}}{{end}}

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -28,7 +28,7 @@ org.broadinstitute.transporter {
         }
 
         gcp {
-            service-account-json = {{env "GCS_WRITER_SA_KEY_PATH"}}
+            service-account-json = "{{env "GCS_WRITER_SA_KEY_PATH"}}"
         }
     }
 }

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -1,4 +1,4 @@
-{{with $aws_secrets_path := env "AWS_SECRETS_PATH"}}{{with $s3_secret := vault $aws_secrets_path}}
+{{with $aws_secrets_path := env "AWS_SECRETS_PATH"}}
 org.broadinstitute.transporter {
 
     kafka {
@@ -24,12 +24,12 @@ org.broadinstitute.transporter {
 
     runner-config {
         aws {
-            access-key-id = "{{$s3_secret.Data.aws_access_key_id}}"
-            secret-access-key = "{{$s3_secret.Data.aws_secret_access_key}}"
+            access-key-id = "{{env "AWS_ACCESS_KEY_ID"}}"
+            secret-access-key = "{{env "AWS_SECRET_ACCESS_KEY"}}"
         }
 
         gcp {
-            service-account-json = "/secrets/gcs/credentials.json"
+            service-account-json = {{env "GCS_WRITER_SA_KEY_PATH"}}
         }
     }
 }

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/application.conf.ctmpl
@@ -1,4 +1,3 @@
-{{with $aws_secrets_path := env "AWS_SECRETS_PATH"}}
 org.broadinstitute.transporter {
 
     kafka {
@@ -33,4 +32,3 @@ org.broadinstitute.transporter {
         }
     }
 }
-{{end}}{{end}}

--- a/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/gcs-writer-sa.json.ctmpl
+++ b/init-containers/transporter-aws-to-gcp-agent/transporter-aws-to-gcp-agent/gcs-writer-sa.json.ctmpl
@@ -1,1 +1,0 @@
-{{with $path := env "GCS_WRITER_SA_PATH"}}{{with $secret := vault $path}}{{$secret.Data | toJSON}}{{end}}{{end}}

--- a/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
@@ -1,9 +1,7 @@
 #!/bin/bash
-{{with $secret := vault (env "DB_LOGIN_SECRETS_PATH")}}
 declare -r LIQUIBASE_HOST='{{env "DB_URL"}}'
 declare -r LIQUIBASE_DATABASE='{{env "DB_NAME"}}'
 declare -r LIQUIBASE_USERNAME='{{env "DB_USERNAME"}}'
 declare -r LIQUIBASE_PASSWORD='{{env "DB_PASSWORD"}}'
 
 exec /usr/local/bin/entrypoint.sh ${@}
-{{end}}

--- a/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager-migrations/entrypoint.sh.ctmpl
@@ -1,9 +1,9 @@
 #!/bin/bash
 {{with $secret := vault (env "DB_LOGIN_SECRETS_PATH")}}
 declare -r LIQUIBASE_HOST='{{env "DB_URL"}}'
-declare -r LIQUIBASE_DATABASE='{{$secret.Data.db_name}}'
-declare -r LIQUIBASE_USERNAME='{{$secret.Data.username}}'
-declare -r LIQUIBASE_PASSWORD='{{$secret.Data.password}}'
+declare -r LIQUIBASE_DATABASE='{{env "DB_NAME"}}'
+declare -r LIQUIBASE_USERNAME='{{env "DB_USERNAME"}}'
+declare -r LIQUIBASE_PASSWORD='{{env "DB_PASSWORD"}}'
 
 exec /usr/local/bin/entrypoint.sh ${@}
 {{end}}

--- a/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
+++ b/init-containers/transporter-manager/transporter-manager/application.conf.ctmpl
@@ -1,11 +1,9 @@
 org.broadinstitute.transporter {
-    {{with $secret := vault (env "DB_LOGIN_SECRETS_PATH")}}
     db {
-        connect-url = "jdbc:postgresql://{{env "DB_URL"}}/{{$secret.Data.db_name}}"
-        username = "{{$secret.Data.username}}"
-        password = "{{$secret.Data.password}}"
+        connect-url = "jdbc:postgresql://{{env "DB_URL"}}/{{env "DB_NAME"}}"
+        username = "{{env "DB_USERNAME"}}"
+        password = "{{env "DB_PASSWORD"}}"
     }
-    {{end}}
     kafka {
         connection {
             bootstrap-servers = ["{{env "KAFKA_BOOTSTRAP_URL"}}"]

--- a/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
+++ b/profiles/persistent-kafka/k8s/kafka/020-Kafka-crd.yaml.ctmpl
@@ -36,3 +36,4 @@ spec:
       deleteClaim: false
   entityOperator:
     topicOperator: {}
+    userOperator: {}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/05-Secret-AWS.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/05-Secret-AWS.yaml.ctmpl
@@ -1,0 +1,13 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $project := env "INGEST_PROJECT"}}
+{{with $secret := secret (printf "secret/dsde/monster/%s/%s/%s/transporter/aws" $env $app $project)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws
+type: Opaque
+data:
+  access-key-id: {{$secret.Data.aws_access_key_id | base64Encode}}
+  secret-access-key: {{$secret.Data.aws_secret_access_key | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/05-Secret-AWS.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/05-Secret-AWS.yaml.ctmpl
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: aws
+  name: transporter-aws-access-keys
 type: Opaque
 data:
   access-key-id: {{$secret.Data.aws_access_key_id | base64Encode}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/06-Secret-GCS.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/06-Secret-GCS.yaml.ctmpl
@@ -1,0 +1,12 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $project := env "INGEST_PROJECT"}}
+{{with $secret := secret (printf "secret/dsde/monster/%s/%s/%s/transporter/gcs-writer-sa-key" $env $app $project)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gcs
+type: Opaque
+data:
+  gcs-writer-sa-key: {{$secret.Data | toJSON | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/06-Secret-GCS.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/06-Secret-GCS.yaml.ctmpl
@@ -5,8 +5,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gcs
+  name: transporter-gcs-sa-key
 type: Opaque
 data:
-  gcs-writer-sa-key: {{$secret.Data | toJSON | base64Encode}}
+  json-key: {{$secret.Data | toJSON | base64Encode}}
 {{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -17,11 +17,11 @@ spec:
     spec:
       serviceAccountName: transporter-agent-sa
       volumes:
-        - name: gcs
+        - name: gcs-sa-key
           secret:
-            secretName: gcs
+            secretName: transporter-gcs-sa-key
             items:
-              - key: gcs-writer-sa-key
+              - key: json-key
                 path: {{$gcsFileName}}
                 mode: 0444
         - name: ca-cert
@@ -35,7 +35,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-aws-to-gcp-agent-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:d688a33
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:01d8017
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: appdir
@@ -59,15 +59,16 @@ spec:
                   key: password
             - name: KAFKA_SCRAM_ALGORITHM
               value: sha-512
+
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: aws
+                  name: transporter-aws-access-keys
                   key: access-key-id
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: aws
+                  name: transporter-aws-access-keys
                   key: secret-access-key
             - name: GCS_WRITER_SA_KEY_PATH
               value: "{{$gcsKeyPath}}/{{$gcsFileName}}"
@@ -105,7 +106,7 @@ spec:
             - name: appdir
               mountPath: /etc/entrypoint.sh
               subPath: transporter-aws-to-gcp-agent/entrypoint.sh
-            - name: gcs
+            - name: gcs-sa-key
               mountPath: {{$gcsKeyPath}}
             - name: ca-cert
               mountPath: /etc/tls

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-agent/10-Deployment.yaml.ctmpl
@@ -2,6 +2,8 @@
 {{with $app := env "APPLICATION_NAME"}}
 {{with $project := env "INGEST_PROJECT"}}
 {{with $owner := env "OWNER"}}
+{{with $gcsKeyPath := "/etc/gcs"}}
+{{with $gcsFileName := "gcs-writer-sa-key.json"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -15,12 +17,12 @@ spec:
     spec:
       serviceAccountName: transporter-agent-sa
       volumes:
-        - name: token
+        - name: gcs
           secret:
-            secretName: vault-token
+            secretName: gcs
             items:
-              - key: token
-                path: token
+              - key: gcs-writer-sa-key
+                path: {{$gcsFileName}}
                 mode: 0444
         - name: ca-cert
           secret:
@@ -36,13 +38,9 @@ spec:
           image: us.gcr.io/broad-dsp-gcr-public/transporter-aws-to-gcp-agent-config:d688a33
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: token
-              mountPath: /etc/vault
             - name: appdir
               mountPath: /working
           env:
-            - name: VAULT_TOKEN_FILE
-              value: /etc/vault/token
 
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
@@ -61,6 +59,18 @@ spec:
                   key: password
             - name: KAFKA_SCRAM_ALGORITHM
               value: sha-512
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: access-key-id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: aws
+                  key: secret-access-key
+            - name: GCS_WRITER_SA_KEY_PATH
+              value: "{{$gcsKeyPath}}/{{$gcsFileName}}"
 
             - name: REQUEST_TOPIC
               value: transporter.requests
@@ -68,11 +78,6 @@ spec:
               value: transporter.progress
             - name: RESULT_TOPIC
               value: transporter.results
-
-            - name: AWS_SECRETS_PATH
-              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/aws
-            - name: GCS_WRITER_SA_PATH
-              value: secret/dsde/monster/{{$env}}/{{$app}}/{{$project}}/transporter/gcs-writer-sa-key
       containers:
         - name: transporter-aws-to-gcp-agent
           image: broadinstitute/transporter-aws-to-gcp-agent:fb7b732b3831a713b1a96b156328d220438f96fd
@@ -100,9 +105,8 @@ spec:
             - name: appdir
               mountPath: /etc/entrypoint.sh
               subPath: transporter-aws-to-gcp-agent/entrypoint.sh
-            - name: appdir
-              mountPath: /secrets/gcs/credentials.json
-              subPath: transporter-aws-to-gcp-agent/gcs-writer-sa.json
+            - name: gcs
+              mountPath: {{$gcsKeyPath}}
             - name: ca-cert
               mountPath: /etc/tls
-{{end}}{{end}}{{end}}{{end}}
+{{end}}{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/05-Secret-DB.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/05-Secret-DB.yaml.ctmpl
@@ -1,0 +1,15 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $ingestProject := env "INGEST_PROJECT"}}
+{{with $owner := env "OWNER"}}
+{{with $secret := secret (printf "secret/dsde/monster/%s/%s/%s/cloudsql/logins/%s" $env $app $ingestProject $owner)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db
+type: Opaque
+data:
+  dbname: {{$secret.Data.db_name | base64Encode}}
+  username: {{$secret.Data.username | base64Encode}}
+  password: {{$secret.Data.password | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/05-Secret-DB.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/05-Secret-DB.yaml.ctmpl
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: db
+  name: transporter-db-login-info
 type: Opaque
 data:
   dbname: {{$secret.Data.db_name | base64Encode}}

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -14,13 +14,6 @@ spec:
     spec:
       serviceAccountName: transporter-manager-sa
       volumes:
-        - name: token
-          secret:
-            secretName: vault-token
-            items:
-              - key: token
-                path: token
-                mode: 0444
         - name: ca-cert
           secret:
             secretName: {{$app}}-cluster-cluster-ca-cert
@@ -35,18 +28,13 @@ spec:
           image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:d688a33
           imagePullPolicy: IfNotPresent
           volumeMounts:
-            - name: token
-              mountPath: /etc/vault
             - name: appdir
               mountPath: /working
           env:
-            - name: VAULT_TOKEN_FILE
-              value: /etc/vault/token
-
             - name: DB_URL
               value: "cloudsql-proxy.{{$owner}}"
             - name: DB_LOGIN_SECRETS_PATH
-              value: {{printf "secret/dsde/monster/%s/%s/%s/cloudsql/logins/%s" $env $app (env "INGEST_PROJECT") $owner}}
+              value: "secret/dsde/monster/{{$env}}/{{$app}}/{{env "INGEST_PROJECT"}}/cloudsql/logins/{{$owner}}"
 
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -33,8 +33,21 @@ spec:
           env:
             - name: DB_URL
               value: "cloudsql-proxy.{{$owner}}"
-            - name: DB_LOGIN_SECRETS_PATH
-              value: "secret/dsde/monster/{{$env}}/{{$app}}/{{env "INGEST_PROJECT"}}/cloudsql/logins/{{$owner}}"
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: dbname
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db
+                  key: password
 
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"

--- a/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/transporter-s3-to-gcs/k8s/transporter-manager/10-Deployment.yaml.ctmpl
@@ -25,7 +25,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: transporter-manager-config
-          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:d688a33
+          image: us.gcr.io/broad-dsp-gcr-public/transporter-manager-config:01d8017
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: appdir
@@ -36,17 +36,17 @@ spec:
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: transporter-db-login-info
                   key: dbname
             - name: DB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: transporter-db-login-info
                   key: username
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: db
+                  name: transporter-db-login-info
                   key: password
 
             - name: KAFKA_BOOTSTRAP_URL

--- a/profiles/user-base/k8s/cloudsql-proxy/05-Secret-CloudSQL.yaml.ctmpl
+++ b/profiles/user-base/k8s/cloudsql-proxy/05-Secret-CloudSQL.yaml.ctmpl
@@ -1,0 +1,14 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $project := env "INGEST_PROJECT"}}
+{{with $instance_secret := secret (printf "secret/dsde/monster/%s/%s/%s/cloudsql/instance" $env $app $project)}}
+{{with $sa_secret := secret (printf "secret/dsde/monster/%s/%s/%s/cloudsql/proxy-sa-key" $env $app $project)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudsql-keys
+type: Opaque
+data:
+  connection-name: {{$instance_secret.Data.connection_name | base64Encode}}
+  credential-file-json: {{$sa_secret.Data | toJSON | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}{{end}}

--- a/profiles/user-base/k8s/cloudsql-proxy/10-Deployment.yaml.ctmpl
+++ b/profiles/user-base/k8s/cloudsql-proxy/10-Deployment.yaml.ctmpl
@@ -1,3 +1,5 @@
+{{with $cloudsqlCredsPath := "/secrets/cloudsql"}}
+{{with $cloudsqlCredsFileName := "credentials.json"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -10,29 +12,26 @@ spec:
         app: cloudsql-proxy
     spec:
       serviceAccountName: cloudsql-proxy-sa
-      initContainers:
-        - name: cloudsql-proxy-config
-          image: us.gcr.io/broad-dsp-gcr-public/cloudsql-proxy-config:ee7998e
-          imagePullPolicy: IfNotPresent
-          env:
-            - name: ENVIRONMENT
-              value: {{env "ENVIRONMENT"}}
-            - name: VAULT_TOKEN_FILE
-              value: /etc/vault/token
-            - name: INSTANCE_VAULT_PATH
-              value: secret/dsde/monster/{{env "ENVIRONMENT"}}/{{env "APPLICATION_NAME"}}/{{env "INGEST_PROJECT"}}/cloudsql/instance
-            - name: SA_VAULT_PATH
-              value: secret/dsde/monster/{{env "ENVIRONMENT"}}/{{env "APPLICATION_NAME"}}/{{env "INGEST_PROJECT"}}/cloudsql/proxy-sa-key
-          volumeMounts:
-            - name: token
-              mountPath: /etc/vault
-            - name: appdir
-              mountPath: /working
+      volumes:
+        - name: cloudsql-keys
+          secret:
+            secretName: cloudsql-keys
+            items:
+              - key: credential-file-json
+                path: {{$cloudsqlCredsFileName}}
+                mode: 0444
       containers:
         - name: cloudsql-proxy
           image: b.gcr.io/cloudsql-docker/gce-proxy:latest
           imagePullPolicy: IfNotPresent
-          command: [ "/bin/sh", "/etc/entrypoint.sh" ]
+          command: ["/cloud_sql_proxy"]
+          args: ["-instances=$(CLOUDSQL_CONNECTION_NAME)=tcp:0.0.0.0:5432", "-credential_file={{$cloudsqlCredsPath}}/{{$cloudsqlCredsFileName}}"]
+          env:
+            - name: CLOUDSQL_CONNECTION_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: cloudsql-keys
+                  key: connection-name
           ports:
             - name: db-port
               containerPort: 5432
@@ -47,20 +46,6 @@ spec:
               port: 5432
             timeoutSeconds: 1
           volumeMounts:
-            - name: appdir
-              mountPath: /secrets/cloudsql/credentials.json
-              subPath: cloudsql-proxy/cloudsql-proxy-sa.json
-              readOnly: true
-            - name: appdir
-              mountPath: /etc/entrypoint.sh
-              subPath: cloudsql-proxy/entrypoint.sh
-      volumes:
-        - name: token
-          secret:
-            secretName: vault-token
-            items:
-              - key: token
-                path: token
-                mode: 0444
-        - name: appdir
-          emptyDir: {}
+            - name: cloudsql-keys
+              mountPath: {{$cloudsqlCredsPath}}
+{{end}}{{end}}

--- a/profiles/user-base/k8s/strimzi-cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
+++ b/profiles/user-base/k8s/strimzi-cluster-operator/050-Deployment-strimzi-cluster-operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: strimzi-cluster-operator
       containers:
       - name: strimzi-cluster-operator
-        image: strimzi/operator:0.12.1
+        image: strimzi/operator:0.12.2
         imagePullPolicy: IfNotPresent
         args:
         - /opt/strimzi/bin/cluster_operator_run.sh
@@ -29,45 +29,45 @@ spec:
         - name: STRIMZI_OPERATION_TIMEOUT_MS
           value: "300000"
         - name: STRIMZI_DEFAULT_ZOOKEEPER_IMAGE
-          value: strimzi/kafka:0.12.1-kafka-2.2.1
+          value: strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ENTITY_OPERATOR_IMAGE
-          value: strimzi/kafka:0.12.1-kafka-2.2.1
+          value: strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_KAFKA_IMAGE
-          value: strimzi/kafka:0.12.1-kafka-2.2.1
+          value: strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_DEFAULT_TLS_SIDECAR_ZOOKEEPER_IMAGE
-          value: strimzi/kafka:0.12.1-kafka-2.2.1
+          value: strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_KAFKA_IMAGES
           value: |
-            2.1.0=strimzi/kafka:0.12.1-kafka-2.1.0
-            2.1.1=strimzi/kafka:0.12.1-kafka-2.1.1
-            2.2.0=strimzi/kafka:0.12.1-kafka-2.2.0
-            2.2.1=strimzi/kafka:0.12.1-kafka-2.2.1
+            2.1.0=strimzi/kafka:0.12.2-kafka-2.1.0
+            2.1.1=strimzi/kafka:0.12.2-kafka-2.1.1
+            2.2.0=strimzi/kafka:0.12.2-kafka-2.2.0
+            2.2.1=strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_KAFKA_CONNECT_IMAGES
           value: |
-            2.1.0=strimzi/kafka:0.12.1-kafka-2.1.0
-            2.1.1=strimzi/kafka:0.12.1-kafka-2.1.1
-            2.2.0=strimzi/kafka:0.12.1-kafka-2.2.0
-            2.2.1=strimzi/kafka:0.12.1-kafka-2.2.1
+            2.1.0=strimzi/kafka:0.12.2-kafka-2.1.0
+            2.1.1=strimzi/kafka:0.12.2-kafka-2.1.1
+            2.2.0=strimzi/kafka:0.12.2-kafka-2.2.0
+            2.2.1=strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_KAFKA_CONNECT_S2I_IMAGES
           value: |
-            2.1.0=strimzi/kafka:0.12.1-kafka-2.1.0
-            2.1.1=strimzi/kafka:0.12.1-kafka-2.1.1
-            2.2.0=strimzi/kafka:0.12.1-kafka-2.2.0
-            2.2.1=strimzi/kafka:0.12.1-kafka-2.2.1
+            2.1.0=strimzi/kafka:0.12.2-kafka-2.1.0
+            2.1.1=strimzi/kafka:0.12.2-kafka-2.1.1
+            2.2.0=strimzi/kafka:0.12.2-kafka-2.2.0
+            2.2.1=strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_KAFKA_MIRROR_MAKER_IMAGES
           value: |
-            2.1.0=strimzi/kafka:0.12.1-kafka-2.1.0
-            2.1.1=strimzi/kafka:0.12.1-kafka-2.1.1
-            2.2.0=strimzi/kafka:0.12.1-kafka-2.2.0
-            2.2.1=strimzi/kafka:0.12.1-kafka-2.2.1
+            2.1.0=strimzi/kafka:0.12.2-kafka-2.1.0
+            2.1.1=strimzi/kafka:0.12.2-kafka-2.1.1
+            2.2.0=strimzi/kafka:0.12.2-kafka-2.2.0
+            2.2.1=strimzi/kafka:0.12.2-kafka-2.2.1
         - name: STRIMZI_DEFAULT_TOPIC_OPERATOR_IMAGE
-          value: strimzi/operator:0.12.1
+          value: strimzi/operator:0.12.2
         - name: STRIMZI_DEFAULT_USER_OPERATOR_IMAGE
-          value: strimzi/operator:0.12.1
+          value: strimzi/operator:0.12.2
         - name: STRIMZI_DEFAULT_KAFKA_INIT_IMAGE
-          value: strimzi/operator:0.12.1
+          value: strimzi/operator:0.12.2
         - name: STRIMZI_DEFAULT_KAFKA_BRIDGE_IMAGE
-          value: strimzi/kafka-bridge:0.12.1
+          value: strimzi/kafka-bridge:0.12.2
         - name: STRIMZI_LOG_LEVEL
           value: INFO
         livenessProbe:

--- a/scripts/build-init-containers
+++ b/scripts/build-init-containers
@@ -5,7 +5,6 @@ declare -r SCRIPT_DIR=$(cd $(dirname $0) && pwd)
 declare -r PROJECT_DIR=$(dirname ${SCRIPT_DIR})
 
 declare -ra INIT_CONTAINER_SERVICES=(
-    cloudsql-proxy
     transporter-manager
     transporter-aws-to-gcp-agent
     openidc-proxy


### PR DESCRIPTION
update .ctmpl files for transporter manager and agent to use kubernetes secrets and then pull all credentials as environment variables in the .sh files. Rendering did not fail for the transporter-s3-to-gcs profile, but I don't know for sure if all the changes work beyond that.