### PR TITLE
DSPDC-340 Manage Kafka consumer group IDs as secrets

### DIFF
--- a/profiles/s3-to-gcs/core.dev.json
+++ b/profiles/s3-to-gcs/core.dev.json
@@ -47,7 +47,8 @@
               "CORE_PROJECT": "broad-dsp-monster-dev",
               "K8S_NODE_COUNT": 3,
               "K8S_MACHINE_TYPE": "n1-standard-2",
-              "ENABLE_DNS": "true"
+              "ENABLE_DNS": "true",
+              "TRANSPORTER_VERSION": "d17d4f47c44abaea4ff5bda53215d19da7eb39d1"
           }
       }
   },

--- a/profiles/s3-to-gcs/k8s/04-transporter-agent/05-Secret-kafka-group-id.yaml.ctmpl
+++ b/profiles/s3-to-gcs/k8s/04-transporter-agent/05-Secret-kafka-group-id.yaml.ctmpl
@@ -1,0 +1,12 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $ingestProject := env "INGEST_PROJECT"}}
+{{with $secret := secret (printf "secret/dsde/monster/%s/%s/%s/kafka/group-ids/transporter" $env $app $ingestProject)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: transporter-agent-group-id
+type: Opaque
+data:
+  id: {{$secret.Data.agent_group | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}

--- a/profiles/s3-to-gcs/k8s/04-transporter-agent/10-Deployment.yaml.ctmpl
+++ b/profiles/s3-to-gcs/k8s/04-transporter-agent/10-Deployment.yaml.ctmpl
@@ -4,7 +4,7 @@
 {{with $owner := env "OWNER"}}
 {{with $gcsKeyPath := "/etc/gcs"}}
 {{with $gcsFileName := "gcs-writer-sa-key.json"}}
-{{with $tag := "cb26babba5e897499ffc44f4b7c399018fd647e6"}}
+{{with $tag := env "TRANSPORTER_VERSION"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -46,7 +46,10 @@ spec:
             - name: KAFKA_BOOTSTRAP_URL
               value: "{{$app}}-cluster-kafka-bootstrap.{{$owner}}:9093"
             - name: KAFKA_APPLICATION_ID
-              value: {{$owner}}-transporter-agent
+              valueFrom:
+                secretKeyRef:
+                  name: transporter-agent-group-id
+                  key: id
             - name: KAFKA_CLUSTER_TRUSTSTORE_PATH
               value: /tmp/client.truststore.jks
             - name: KAFKA_CLUSTER_TRUSTSTORE_PASSWORD

--- a/profiles/s3-to-gcs/k8s/04-transporter-manager/05-Secret-kafka-group-id.yaml.ctmpl
+++ b/profiles/s3-to-gcs/k8s/04-transporter-manager/05-Secret-kafka-group-id.yaml.ctmpl
@@ -1,0 +1,12 @@
+{{with $env := env "ENVIRONMENT"}}
+{{with $app := env "APPLICATION_NAME"}}
+{{with $ingestProject := env "INGEST_PROJECT"}}
+{{with $secret := secret (printf "secret/dsde/monster/%s/%s/%s/kafka/group-ids/transporter" $env $app $ingestProject)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: transporter-manager-group-id
+type: Opaque
+data:
+  id: {{$secret.Data.manager_group | base64Encode}}
+{{end}}{{end}}{{end}}{{end}}

--- a/profiles/s3-to-gcs/k8s/04-transporter-manager/10-Deployment.yaml.ctmpl
+++ b/profiles/s3-to-gcs/k8s/04-transporter-manager/10-Deployment.yaml.ctmpl
@@ -1,7 +1,7 @@
 {{with $env := env "ENVIRONMENT"}}
 {{with $app := env "APPLICATION_NAME"}}
 {{with $owner := env "OWNER"}}
-{{with $tag := "cb26babba5e897499ffc44f4b7c399018fd647e6"}}
+{{with $tag := env "TRANSPORTER_VERSION"}}
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -65,6 +65,11 @@ spec:
                   key: password
             - name: KAFKA_SCRAM_ALGORITHM
               value: sha-512
+            - name: KAFKA_GROUP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: transporter-manager-group-id
+                  key: id
 
             - name: REQUEST_TOPIC
               value: transporter.requests

--- a/profiles/s3-to-gcs/terraform/all-the-things/database.tf
+++ b/profiles/s3-to-gcs/terraform/all-the-things/database.tf
@@ -1,11 +1,3 @@
-resource "google_sql_database" "transporter-db" {
-    name = "${var.app_name}-transporter-db"
-    project = var.google_project
-    instance = google_sql_database_instance.postgres-100.name
-    charset = "UTF8"
-    collation = "en_US.UTF8"
-}
-
 resource "random_id" "transporter-db-password" {
     byte_length = 16
 }
@@ -15,7 +7,15 @@ resource "google_sql_user" "transporter-db-user" {
     password = random_id.transporter-db-password.hex
     project = var.google_project
     instance = google_sql_database_instance.postgres-100.name
-    depends_on = [google_sql_database.transporter-db]
+}
+
+resource "google_sql_database" "transporter-db" {
+    name = "${var.app_name}-transporter-db"
+    project = var.google_project
+    instance = google_sql_database_instance.postgres-100.name
+    charset = "UTF8"
+    collation = "en_US.UTF8"
+    depends_on = [google_sql_user.transporter-db-user]
 }
 
 resource "vault_generic_secret" "transporter-db-login-secret" {

--- a/profiles/s3-to-gcs/terraform/all-the-things/vault-secrets.tf
+++ b/profiles/s3-to-gcs/terraform/all-the-things/vault-secrets.tf
@@ -1,0 +1,14 @@
+resource "random_id" "transporter-group-id-suffix" {
+    byte_length = 16
+    depends_on = [module.enable-services]
+}
+
+resource "vault_generic_secret" "transporter-group-id-secret" {
+    path = "secret/dsde/monster/${var.env}/${var.app_name}/${var.ingest_project}/kafka/group-ids/transporter"
+    data_json = <<EOT
+{
+    "manager_group": "transporter-managers-${random_id.transporter-group-id-suffix.hex}",
+    "agent_group": "transporter-agents-${random_id.transporter-group-id-suffix.hex}"
+}
+EOT
+}

--- a/profiles/s3-to-gcs/v2f.prod.json
+++ b/profiles/s3-to-gcs/v2f.prod.json
@@ -47,7 +47,8 @@
               "CORE_PROJECT": "broad-dsp-monster-prod",
               "K8S_NODE_COUNT": 5,
               "K8S_MACHINE_TYPE": "n1-standard-4",
-              "ENABLE_DNS": "true"
+              "ENABLE_DNS": "true",
+              "TRANSPORTER_VERSION": "d17d4f47c44abaea4ff5bda53215d19da7eb39d1"
           }
       }
   },


### PR DESCRIPTION
1. Generate consumer group IDs in Terraform, and write them to Vault
2. Use the info from Vault to generate k8s secrets
3. Use the k8s secrets to render application config

When we enable the Kafka authorizer in DSPDC-326, we can add user-level ACLs to the group IDs ensuring only the expected users can join each group.