### PR TITLE
DSPDC-569 Add toggle for max message size.

### DIFF
--- a/templates/sftp-to-gcs/anvil-emerge.prod.json
+++ b/templates/sftp-to-gcs/anvil-emerge.prod.json
@@ -22,7 +22,7 @@
       "DNS_ZONE_NAME": "gotc-prod",
       "K8S_NODE_COUNT": 3,
       "K8S_MACHINE_TYPE": "n1-standard-4",
-      "TRANSPORTER_VERSION": "476c05f93356b80726a86b219e8b79aac387107e",
+      "TRANSPORTER_VERSION": "7640c60069af6fed1d85b00220ba73a0d2f4519b",
       "ENABLE_DNS": true,
       "TRANSPORTER_DNS_NAME": "emerge-transporter",
       "TLS_KEY_SECRET": "secret/dsde/gotc/prod/common/server.key",
@@ -45,7 +45,7 @@
         "sahakian@broadinstitute.org",
         "spletche@broadinstitute.org"
       ],
-      "TRANSPORTER_AGENT_COUNT": 12,
+      "TRANSPORTER_AGENT_COUNT": 8,
       "TRANSPORTER_AGENT_PARTITION_COUNT": 16,
       "KAFKA_RAM_GB": 3,
       "KAFKA_DISK_SIZE_GB": 10,

--- a/templates/sftp-to-gcs/anvil-emerge.prod.json
+++ b/templates/sftp-to-gcs/anvil-emerge.prod.json
@@ -22,7 +22,7 @@
       "DNS_ZONE_NAME": "gotc-prod",
       "K8S_NODE_COUNT": 3,
       "K8S_MACHINE_TYPE": "n1-standard-4",
-      "TRANSPORTER_VERSION": "e86994bed619f1f732247b13ef00e675ff6d14a7",
+      "TRANSPORTER_VERSION": "476c05f93356b80726a86b219e8b79aac387107e",
       "ENABLE_DNS": true,
       "TRANSPORTER_DNS_NAME": "emerge-transporter",
       "TLS_KEY_SECRET": "secret/dsde/gotc/prod/common/server.key",
@@ -45,10 +45,11 @@
         "sahakian@broadinstitute.org",
         "spletche@broadinstitute.org"
       ],
-      "TRANSPORTER_AGENT_COUNT": 8,
+      "TRANSPORTER_AGENT_COUNT": 12,
       "TRANSPORTER_AGENT_PARTITION_COUNT": 16,
       "KAFKA_RAM_GB": 3,
       "KAFKA_DISK_SIZE_GB": 10,
-      "MIB_PER_TRANSFER_STEP": 512
+      "MIB_PER_TRANSFER_STEP": 16,
+      "KAFKA_MAX_MESSAGE_SIZE_MIB": 15
   }
 }

--- a/templates/sftp-to-gcs/k8s/02-kafka-cluster/10-Kafka-cluster.yaml.ctmpl
+++ b/templates/sftp-to-gcs/k8s/02-kafka-cluster/10-Kafka-cluster.yaml.ctmpl
@@ -17,6 +17,12 @@ spec:
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 2
       log.message.format.version: "2.2"
+      {{with $maxMib := env "KAFKA_MAX_MESSAGE_SIZE_MIB" | parseInt}}
+      {{with $maxBytes := multiply $maxMib 1024 | multiply 1024}}
+      replica.fetch.max.bytes: {{$maxBytes}}
+      replica.fetch.response.max.bytes: {{$maxBytes}}
+      message.max.bytes: {{$maxBytes}}
+      {{end}}{{end}}
     storage:
       type: jbod
       volumes:

--- a/templates/sftp-to-gcs/k8s/04-transporter-agent/10-Deployment.yaml.ctmpl
+++ b/templates/sftp-to-gcs/k8s/04-transporter-agent/10-Deployment.yaml.ctmpl
@@ -57,6 +57,8 @@ spec:
                   key: password
             - name: KAFKA_SCRAM_ALGORITHM
               value: sha-512
+            - name: KAFKA_MAX_MESSAGE_SIZE_MIB
+              value: "{{env "KAFKA_MAX_MESSAGE_SIZE_MIB"}}"
 
             - name: SFTP_HOST
               valueFrom:


### PR DESCRIPTION
* Add a new "max size" argument to the template
* Pass the max through to the init containers for the Transporter agents
* Use the max to configure settings in the Kafka brokers via strimzi